### PR TITLE
ci: add GitHub Actions OIDC workflow and Terraform configuration for ECR push

### DIFF
--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -1,0 +1,56 @@
+name: Push to ECR on Main Merge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/push-to-ecr.yml'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  push-to-ecr:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+
+      - name: Get AWS Account ID and ECR login
+        id: ecr-login
+        run: |
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "aws_account_id=${AWS_ACCOUNT_ID}" >> $GITHUB_OUTPUT
+          aws ecr get-login-password --region ap-northeast-1 | \
+            docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com
+
+      - name: Build and push Docker image to ECR
+        run: |
+          AWS_ACCOUNT_ID=${{ steps.ecr-login.outputs.aws_account_id }}
+          REPO_URL=${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/yohei-app
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          
+          docker build -t yohei-app:sha-${COMMIT_HASH} .
+          docker tag yohei-app:sha-${COMMIT_HASH} ${REPO_URL}:sha-${COMMIT_HASH}
+          docker tag yohei-app:sha-${COMMIT_HASH} ${REPO_URL}:latest
+          
+          docker push ${REPO_URL}:sha-${COMMIT_HASH}
+          docker push ${REPO_URL}:latest
+          
+          echo "Image pushed: ${REPO_URL}:latest (sha-${COMMIT_HASH})"
+
+      - name: Notify on success
+        run: echo "✓ Docker image successfully pushed to ECR"

--- a/docs/github-actions-ecr-setup.md
+++ b/docs/github-actions-ecr-setup.md
@@ -1,0 +1,182 @@
+# GitHub Actions ECR Push Setup
+
+## 概要
+
+このワークフロー `.github/workflows/push-to-ecr.yml` は、PR が main ブランチにマージされたときに自動的に Docker イメージをビルドして AWS ECR にプッシュします。
+
+## セットアップ手順
+
+### 1. IAM ロール（OIDC）の作成
+
+GitHub Actions が AWS にアクセスするため、OpenID Connect (OIDC) を使った短期認証を設定します。
+
+#### AWS 側の設定
+
+```bash
+# IAM OIDC プロバイダーを作成
+aws iam create-openid-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+
+# IAM ロールを作成（信頼ポリシー付き）
+cat > trust-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::YOUR_AWS_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:kanra824/yohei-app:ref:refs/heads/main"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+# ロールを作成
+aws iam create-role \
+  --role-name github-actions-ecr-push \
+  --assume-role-policy-document file://trust-policy.json
+```
+
+#### 権限ポリシーを付与
+
+```bash
+cat > ecr-push-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Resource": "arn:aws:ecr:ap-northeast-1:YOUR_AWS_ACCOUNT_ID:repository/yohei-app"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+# ロールにポリシーを付与
+aws iam put-role-policy \
+  --role-name github-actions-ecr-push \
+  --policy-name ECRPushPolicy \
+  --policy-document file://ecr-push-policy.json
+```
+
+### 2. GitHub Repository Secrets の設定
+
+GitHub リポジトリの Settings → Secrets and variables → Actions から以下を追加：
+
+- **Name:** `AWS_ROLE_TO_ASSUME`
+- **Value:** `arn:aws:iam::YOUR_AWS_ACCOUNT_ID:role/github-actions-ecr-push`
+
+`YOUR_AWS_ACCOUNT_ID` を自分のアカウント ID に置き換えてください。
+
+### 3. ワークフローの動作確認
+
+1. PR を作成して main にマージする
+2. GitHub Actions タブでワークフローの実行を確認
+3. ECR コンソールでイメージが push されたことを確認
+
+```bash
+# コマンドラインで確認
+aws ecr list-images --repository-name yohei-app --region ap-northeast-1
+```
+
+## ワークフローの詳細
+
+### トリガー条件
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'          # backend 配下の変更のみ
+      - '.github/workflows/push-to-ecr.yml'  # ワークフロー自体の変更
+```
+
+### 実行内容
+
+1. **Checkout:** リポジトリをチェックアウト
+2. **AWS 認証:** OIDC を使用して AWS に認証
+3. **ECR ログイン:** docker login で ECR に認証
+4. **ビルド・プッシュ:** Docker イメージをビルドして ECR にプッシュ
+   - タグ: `sha-<COMMIT_HASH>`（コミット用）
+   - タグ: `latest`（最新版）
+
+## トラブルシューティング
+
+### エラー: "Could not retrieve ECR access token"
+
+**原因:** IAM ロールの権限不足
+
+**解決策:** IAM ポリシーを確認し、`ecr:GetAuthorizationToken` が付与されているか確認
+
+```bash
+aws iam get-role-policy \
+  --role-name github-actions-ecr-push \
+  --policy-name ECRPushPolicy
+```
+
+### エラー: "UnauthorizedOperation: User is not authorized"
+
+**原因:** GitHub の OIDC トークンの subject が信頼ポリシーと一致していない
+
+**確認方法:**
+```bash
+# 信頼ポリシーを確認
+aws iam get-role --role-name github-actions-ecr-push
+```
+
+### イメージが push されない
+
+**チェックリスト:**
+- [ ] ワークフローファイルが `.github/workflows/push-to-ecr.yml` に存在
+- [ ] PR が main ブランチにマージされた（push ではなくマージ）
+- [ ] `backend/` 配下に変更がある
+- [ ] AWS 認証情報が正しく設定されている
+- [ ] GitHub Actions ログで詳細なエラーを確認
+
+## 手動実行（テスト用）
+
+ワークフローを手動で実行する場合（リポジトリの Actions タブから）：
+
+```bash
+# ワークフローに手動トリガーを追加する場合
+on:
+  workflow_dispatch:
+```
+
+## セキュリティのベストプラクティス
+
+- ✅ **OIDC 使用:** 長期的な AWS 認証情報を保存しない
+- ✅ **権限最小化:** 必要な ECR 操作のみを許可
+- ✅ **Subject 制限:** `main` ブランチのみに制限
+- ✅ **パス制限:** `backend/**` の変更のみトリガー
+
+## 参考資料
+
+- [GitHub Actions - AWS authentication](https://github.com/aws-actions/configure-aws-credentials)
+- [AWS OIDC Provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for_user_oidc.html)

--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -1,0 +1,74 @@
+# --- GitHub Actions OIDC Provider ----------------------------------------
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+  ]
+
+  tags = {
+    Name = "github-actions-oidc"
+  }
+}
+
+# --- GitHub Actions ECR Push IAM Role --------------------------------------
+resource "aws_iam_role" "github_actions_ecr" {
+  name = "github-actions-ecr-push"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            "token.actions.githubusercontent.com:sub" = "repo:kanra824/yohei-app:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "github-actions-ecr-push"
+  }
+}
+
+# --- ECR Push Permission Policy -------------------------------------------
+resource "aws_iam_role_policy" "github_actions_ecr_push" {
+  name = "ecr-push-policy"
+  role = aws_iam_role.github_actions_ecr.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+        ]
+        Resource = aws_ecr_repository.app.arn
+      },
+    ]
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,3 +17,13 @@ output "ecs_service_name" {
   value       = aws_ecs_service.app.name
   description = "The name of the ECS service"
 }
+
+output "github_actions_role_arn" {
+  value       = aws_iam_role.github_actions_ecr.arn
+  description = "ARN of the IAM role for GitHub Actions to assume for ECR push"
+}
+
+output "github_actions_role_name" {
+  value       = aws_iam_role.github_actions_ecr.name
+  description = "Name of the IAM role for GitHub Actions"
+}


### PR DESCRIPTION
## 概要

GitHub Actions から AWS ECR への Docker イメージプッシュを自動化するための設定を追加しました。

OIDC（OpenID Connect）を使用した安全な認証を実装しており、長期的な AWS 認証情報を保存する必要がありません。

## 変更内容

### 1. GitHub Actions ワークフロー (.github/workflows/push-to-ecr.yml)
- main ブランチへのプッシュをトリガー
- backend/ 配下の変更時のみ実行
- AWS OIDC を使用した安全な認証
- Docker イメージのビルドと ECR へのプッシュを自動化
- タグ: `latest` と `sha-<COMMIT_HASH>`

### 2. Terraform 設定 (terraform/github-actions.tf, terraform/outputs.tf)
- AWS IAM OIDC プロバイダー作成
- GitHub Actions 用 IAM ロール定義
- Trust Policy で main ブランチのみに制限
- ECR プッシュ権限を最小権限の原則に従い設定

### 3. セットアップドキュメント (docs/github-actions-ecr-setup.md)
- IAM ロール（OIDC）の作成手順
- GitHub Secrets の設定方法
- トラブルシューティングガイド

## セットアップ手順

1. Terraform を適用して AWS リソースを作成
   ```bash
   cd terraform
   terraform apply
   ```

2. ロール ARN を取得
   ```bash
   terraform output github_actions_role_arn
   ```

3. GitHub リポジトリ Settings → Secrets and variables → Actions で設定
   - **Name:** `AWS_ROLE_TO_ASSUME`
   - **Value:** 上記で取得した ARN

4. PR を main にマージ
   → ワークフロー実行、Docker イメージが ECR にプッシュされます

## セキュリティ

- ✅ 長期的な AWS 認証情報を保存しない（OIDC使用）
- ✅ main ブランチからのプッシュのみ許可
- ✅ IAM 権限を ECR プッシュに限定（最小権限の原則）
- ✅ 一時認証情報は自動削除（ワークフロー終了時）

## イメージタグ

- `latest`: 常に最新のプロダクションイメージ
- `sha-<COMMIT_HASH>`: コミット毎の追跡可能なタグ
