### PR TITLE
feat: add ECS auto-deployment to GitHub Actions workflow

### DIFF
--- a/.github/workflows/push-to-ecr.yml
+++ b/.github/workflows/push-to-ecr.yml
@@ -38,6 +38,7 @@ jobs:
             docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com
 
       - name: Build and push Docker image to ECR
+        id: build-image
         run: |
           AWS_ACCOUNT_ID=${{ steps.ecr-login.outputs.aws_account_id }}
           REPO_URL=${AWS_ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/yohei-app
@@ -50,7 +51,26 @@ jobs:
           docker push ${REPO_URL}:sha-${COMMIT_HASH}
           docker push ${REPO_URL}:latest
           
+          echo "image=${REPO_URL}:latest" >> $GITHUB_OUTPUT
           echo "Image pushed: ${REPO_URL}:latest (sha-${COMMIT_HASH})"
 
-      - name: Notify on success
-        run: echo "✓ Docker image successfully pushed to ECR"
+      - name: Deploy to ECS
+        run: |
+          # ECS サービスを強制的に新しいデプロイメントで更新
+          aws ecs update-service \
+            --cluster yohei-app-cluster \
+            --service yohei-app-service \
+            --force-new-deployment \
+            --region ap-northeast-1
+          
+          echo "✓ ECS service deployment initiated"
+
+      - name: Wait for deployment to complete
+        run: |
+          echo "Waiting for ECS deployment to stabilize..."
+          aws ecs wait services-stable \
+            --cluster yohei-app-cluster \
+            --services yohei-app-service \
+            --region ap-northeast-1
+          
+          echo "✓ ECS deployment completed successfully"

--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -72,3 +72,29 @@ resource "aws_iam_role_policy" "github_actions_ecr_push" {
     ]
   })
 }
+
+# --- ECS Deploy Permission Policy ------------------------------------------
+resource "aws_iam_role_policy" "github_actions_ecs_deploy" {
+  name = "ecs-deploy-policy"
+  role = aws_iam_role.github_actions_ecr.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecs:UpdateService",
+          "ecs:DescribeServices",
+        ]
+        Resource = aws_ecs_service.app.id
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:PassRole",
+        ]
+        Resource = aws_iam_role.ecs_task_execution.arn
+      },
+    ]
+  })
+}

--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -15,9 +15,9 @@ resource "aws_iam_openid_connect_provider" "github" {
   }
 }
 
-# --- GitHub Actions ECR Push IAM Role --------------------------------------
-resource "aws_iam_role" "github_actions_ecr" {
-  name = "github-actions-ecr-push"
+# --- GitHub Actions IAM Role -----------------------------------------------
+resource "aws_iam_role" "github_actions_role" {
+  name = "github-actions-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -39,14 +39,14 @@ resource "aws_iam_role" "github_actions_ecr" {
   })
 
   tags = {
-    Name = "github-actions-ecr-push"
+    Name = "github-actions-role"
   }
 }
 
 # --- ECR Push Permission Policy -------------------------------------------
 resource "aws_iam_role_policy" "github_actions_ecr_push" {
   name = "ecr-push-policy"
-  role = aws_iam_role.github_actions_ecr.id
+  role = aws_iam_role.github_actions_role.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -76,7 +76,7 @@ resource "aws_iam_role_policy" "github_actions_ecr_push" {
 # --- ECS Deploy Permission Policy ------------------------------------------
 resource "aws_iam_role_policy" "github_actions_ecs_deploy" {
   name = "ecs-deploy-policy"
-  role = aws_iam_role.github_actions_ecr.id
+  role = aws_iam_role.github_actions_role.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -19,11 +19,11 @@ output "ecs_service_name" {
 }
 
 output "github_actions_role_arn" {
-  value       = aws_iam_role.github_actions_ecr.arn
-  description = "ARN of the IAM role for GitHub Actions to assume for ECR push"
+  value       = aws_iam_role.github_actions_role.arn
+  description = "ARN of the IAM role for GitHub Actions to assume for ECR push and ECS deployment"
 }
 
 output "github_actions_role_name" {
-  value       = aws_iam_role.github_actions_ecr.name
+  value       = aws_iam_role.github_actions_role.name
   description = "Name of the IAM role for GitHub Actions"
 }


### PR DESCRIPTION
## 概要

GitHub Actions ワークフローに ECS サービスの自動デプロイ機能を追加しました。

ECR にイメージを push した後、自動的に ECS サービスを更新して新しいイメージをデプロイします。

## 変更内容

### 1. GitHub Actions ワークフロー (.github/workflows/push-to-ecr.yml)
- ECS サービス更新ステップを追加（`aws ecs update-service --force-new-deployment`）
- デプロイ完了まで待機する処理を追加（`aws ecs wait services-stable`）
- イメージ push 後に自動的に ECS にデプロイ

### 2. Terraform IAM 権限 (terraform/github-actions.tf)
- ECS サービス更新権限を追加（`ecs:UpdateService`, `ecs:DescribeServices`）
- PassRole 権限を追加（ECS タスク実行ロールに必要）

## 動作フロー

```
PR を main にマージ
  ↓
GitHub Actions トリガー
  ↓
Docker イメージをビルド
  ↓
ECR に push (latest + sha-xxx)
  ↓
ECS サービスを強制更新
  ↓
デプロイ完了まで待機
  ↓
新しいイメージで稼働開始
```

## 前提条件

- Terraform で IAM 権限を適用済み
- `AWS_ROLE_TO_ASSUME` が Secrets に設定済み

## 確認方法

マージ後、以下で確認：
```bash
# ECS サービスのタスク定義を確認
aws ecs describe-services --cluster yohei-app-cluster --services yohei-app-service --region ap-northeast-1

# 実行中のタスクを確認
aws ecs list-tasks --cluster yohei-app-cluster --service yohei-app-service --region ap-northeast-1
```
