### PR TITLE
fix: OIDC trust policy で StringLike を使用してワイルドカード対応

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,7 @@ docker compose up
 # ブラウザで localhost:8000 にアクセス
 ```
 
-## ECR に push (TODO: CI 生やす)
+## ECR に push (GitHub Actions で自動デプロイ)
 ```
 ./scripts/push_to_ecr.sh
 ```

--- a/terraform/github-actions.tf
+++ b/terraform/github-actions.tf
@@ -29,9 +29,11 @@ resource "aws_iam_role" "github_actions_role" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:kanra824/yohei-app:*"
+          }
           StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-            "token.actions.githubusercontent.com:sub" = "repo:kanra824/yohei-app:ref:refs/heads/main"
           }
         }
       }


### PR DESCRIPTION
## 問題
GitHub Actions で OIDC 認証時に `Not authorized to perform sts:AssumeRoleWithWebIdentity` エラーが発生していました。

## 原因
IAM ロールの信頼ポリシーで `StringEquals` と特定ブランチ参照 (`ref:refs/heads/main`) を使用していましたが、GitHub Actions の OIDC トークンの `sub` クレームと完全一致しませんでした。

## 解決策
- `StringEquals` → `StringLike` に変更
- `repo:kanra824/yohei-app:ref:refs/heads/main` → `repo:kanra824/yohei-app:*` にワイルドカード化
- これにより任意のブランチ・タグからの認証が可能になります

## 参考
https://zenn.dev/zuzuzu/articles/oidc_aws_actions

## 変更内容
- `terraform/github-actions.tf`: IAM ロール信頼ポリシーを修正
- `backend/README.md`: TODO コメントを更新 (自動デプロイ対応済み)