### PR TITLE
feat: HTTPS 対応とカスタムドメイン (kanra824.com) 設定

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -30,7 +30,27 @@ resource "aws_lb_listener" "http" {
   protocol          = "HTTP"
 
   default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.main.arn
+
+  default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.tg.arn
   }
+
+  depends_on = [aws_acm_certificate_validation.main]
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,72 @@
+# --- Route 53 Hosted Zone (既存のものをインポート) -----------------------
+data "aws_route53_zone" "main" {
+  name = "kanra824.com"
+}
+
+# --- ACM Certificate -------------------------------------------------------
+resource "aws_acm_certificate" "main" {
+  domain_name       = "kanra824.com"
+  validation_method = "DNS"
+
+  subject_alternative_names = [
+    "www.kanra824.com"
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "kanra824.com"
+  }
+}
+
+# --- ACM Certificate Validation Records ------------------------------------
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.main.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.main.zone_id
+}
+
+# --- ACM Certificate Validation --------------------------------------------
+resource "aws_acm_certificate_validation" "main" {
+  certificate_arn         = aws_acm_certificate.main.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# --- Route 53 A Record (kanra824.com → ALB) --------------------------------
+resource "aws_route53_record" "root" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "kanra824.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# --- Route 53 A Record (www.kanra824.com → ALB) ----------------------------
+resource "aws_route53_record" "www" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "www.kanra824.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.alb.dns_name
+    zone_id                = aws_lb.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -27,3 +27,13 @@ output "github_actions_role_name" {
   value       = aws_iam_role.github_actions_role.name
   description = "Name of the IAM role for GitHub Actions"
 }
+
+output "domain_name" {
+  value       = "https://kanra824.com"
+  description = "The domain name of the application"
+}
+
+output "certificate_arn" {
+  value       = aws_acm_certificate.main.arn
+  description = "ARN of the ACM certificate"
+}

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -10,6 +10,13 @@ resource "aws_security_group" "alb_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
## 概要
カスタムドメイン `kanra824.com` で HTTPS アクセスを可能にしました。

## 実装内容

### 1. ACM 証明書
- `kanra824.com` と `www.kanra824.com` 用の無料 SSL/TLS 証明書を作成
- DNS 検証を Route 53 で自動化

### 2. ALB HTTPS リスナー
- ポート 443 で HTTPS リクエストを受信
- TLS 1.3 対応のセキュリティポリシーを使用

### 3. HTTP → HTTPS リダイレクト
- ポート 80 へのアクセスを 443 に 301 リダイレクト
- ユーザーが `http://` でアクセスしても自動的に HTTPS に転送

### 4. Route 53 DNS 設定
- `kanra824.com` → ALB への A レコード（Alias）
- `www.kanra824.com` → ALB への A レコード（Alias）

### 5. セキュリティグループ更新
- ALB でポート 443 (HTTPS) を許可

## ファイル変更
- `terraform/dns.tf`: 新規作成（ACM 証明書、Route 53 レコード）
- `terraform/alb.tf`: HTTPS リスナー追加、HTTP リダイレクト設定
- `terraform/security.tf`: ポート 443 許可
- `terraform/outputs.tf`: ドメイン情報と証明書 ARN を出力

## アクセス方法
- https://kanra824.com
- https://www.kanra824.com
- http://kanra824.com （自動的に HTTPS にリダイレクト）

## コスト
- ACM 証明書: 無料
- Route 53 A レコード（Alias）: クエリ無料
- HTTPS リスナー: HTTP と同じ料金（追加コストなし）